### PR TITLE
fix: Fixed env-config to make NODE_ENV optional

### DIFF
--- a/src/config/env-config.ts
+++ b/src/config/env-config.ts
@@ -2,15 +2,18 @@ import { z } from 'zod';
 
 type EnvConfig = {
   backendUrl: string;
+  baseUrl: string;
   environment: 'development' | 'production';
   port: number;
-  baseUrl: string;
 };
 
 const envConfigSchema = z.object({
   NEXT_PUBLIC_BACKEND_URL: z.string().min(1),
   NEXT_PUBLIC_BASE_URL: z.string().min(1),
-  NODE_ENV: z.enum(['development', 'production']),
+  NODE_ENV: z
+    .enum(['development', 'production'])
+    .optional()
+    .default('development'),
   PORT: z.coerce.number().optional().default(3000),
 });
 


### PR DESCRIPTION
The `NODE_ENV` env variable is usually set in the environment in production and during development you can set it via `.env` files.  So we don't need to enforce it.